### PR TITLE
Add Redis-backed storage for domain models

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           tox-envs: 'lint,typing,py,coverage-report'
+          tox-plugins: "tox-docker"
 
   build:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v3.0.0-alpha.4'
+    rev: 'v3.0.0-alpha.6'
     hooks:
       - id: prettier
         types: [css, javascript]
@@ -19,7 +19,7 @@ repos:
           - tomli
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ init:
 	pip install --editable .
 	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
-	pip install --upgrade tox
+	pip install --upgrade tox tox-docker
 	pre-commit install
 
 .PHONY: update

--- a/manifests/base/configmap.yaml
+++ b/manifests/base/configmap.yaml
@@ -12,3 +12,4 @@ data:
   SAFIR_LOGGER: "spherexportal"
   SAFIR_LOG_LEVEL: "INFO"
   PORTAL_DATASET_PATH: "/opt/spherex-doc-portal/dataset/dataset.yaml"
+  PORTAL_REDIS_URL: "redis://redis:6379/0"

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -17,3 +17,4 @@ pytest-asyncio
 pytest-cov
 types-PyYAML
 types-cachetools
+types-redis

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,66 +8,77 @@ anyio==3.6.2
     # via
     #   -c requirements/main.txt
     #   httpcore
-asgi-lifespan==2.0.0
+asgi-lifespan==2.1.0
     # via -r requirements/dev.in
-attrs==22.2.0
-    # via pytest
 certifi==2022.12.7
     # via
     #   -c requirements/main.txt
     #   httpcore
     #   httpx
+cffi==1.15.1
+    # via
+    #   -c requirements/main.txt
+    #   cryptography
 cfgv==3.3.1
     # via pre-commit
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/dev.in
     #   pytest-cov
+cryptography==40.0.2
+    # via
+    #   -c requirements/main.txt
+    #   types-pyopenssl
+    #   types-redis
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.12.0
     # via virtualenv
 h11==0.14.0
     # via
     #   -c requirements/main.txt
     #   httpcore
-httpcore==0.16.3
+httpcore==0.17.0
     # via
     #   -c requirements/main.txt
     #   httpx
-httpx==0.23.3
+httpx==0.24.0
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
-identify==2.5.18
+identify==2.5.22
     # via pre-commit
 idna==3.4
     # via
     #   -c requirements/main.txt
     #   anyio
-    #   rfc3986
+    #   httpx
 iniconfig==2.0.0
     # via pytest
-mypy==1.0.1
+mypy==1.2.0
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.7.0
     # via pre-commit
-packaging==23.0
+packaging==23.1
     # via pytest
-platformdirs==3.1.0
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==3.1.1
+pre-commit==3.2.2
     # via -r requirements/dev.in
-pytest==7.2.2
+pycparser==2.21
+    # via
+    #   -c requirements/main.txt
+    #   cffi
+pytest==7.3.1
     # via
     #   -r requirements/dev.in
     #   pytest-asyncio
     #   pytest-cov
-pytest-asyncio==0.20.3
+pytest-asyncio==0.21.0
     # via -r requirements/dev.in
 pytest-cov==4.0.0
     # via -r requirements/dev.in
@@ -75,10 +86,6 @@ pyyaml==6.0
     # via
     #   -c requirements/main.txt
     #   pre-commit
-rfc3986[idna2008]==1.5.0
-    # via
-    #   -c requirements/main.txt
-    #   httpx
 sniffio==1.3.0
     # via
     #   -c requirements/main.txt
@@ -86,15 +93,19 @@ sniffio==1.3.0
     #   asgi-lifespan
     #   httpcore
     #   httpx
-types-cachetools==5.3.0.4
+types-cachetools==5.3.0.5
     # via -r requirements/dev.in
-types-pyyaml==6.0.12.8
+types-pyopenssl==23.1.0.2
+    # via types-redis
+types-pyyaml==6.0.12.9
+    # via -r requirements/dev.in
+types-redis==4.5.4.1
     # via -r requirements/dev.in
 typing-extensions==4.5.0
     # via
     #   -c requirements/main.txt
     #   mypy
-virtualenv==20.20.0
+virtualenv==20.22.0
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -11,7 +11,7 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir
+safir[redis]
 pydantic
 PyYAML
 Jinja2

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -9,6 +9,8 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
+async-timeout==4.0.2
+    # via redis
 asyncache==0.3.1
     # via -r requirements/main.in
 aws-request-signer==1.2.0
@@ -25,19 +27,27 @@ certifi==2022.12.7
     # via
     #   httpcore
     #   httpx
+cffi==1.15.1
+    # via cryptography
 click==8.1.3
     # via
     #   panflute
     #   typer
     #   uvicorn
+cryptography==40.0.2
+    # via
+    #   pyjwt
+    #   safir
 dnspython==2.3.0
     # via email-validator
-email-validator==1.3.1
+email-validator==2.0.0.post2
     # via lander
-fastapi==0.92.0
+fastapi==0.95.1
     # via
     #   -r requirements/main.in
     #   safir
+gidgethub==5.2.1
+    # via safir
 gitdb==4.0.10
     # via gitpython
 gitpython==3.1.31
@@ -46,11 +56,11 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.16.3
+httpcore==0.17.0
     # via httpx
 httptools==0.5.0
     # via uvicorn
-httpx==0.23.3
+httpx==0.24.0
     # via
     #   -r requirements/main.in
     #   safir
@@ -58,7 +68,7 @@ idna==3.4
     # via
     #   anyio
     #   email-validator
-    #   rfc3986
+    #   httpx
 jinja2==3.1.2
     # via
     #   -r requirements/main.in
@@ -69,12 +79,16 @@ markupsafe==2.1.2
     # via jinja2
 panflute==2.3.0
     # via lander
-pydantic==1.10.5
+pycparser==2.21
+    # via cffi
+pydantic==1.10.7
     # via
     #   -r requirements/main.in
     #   fastapi
     #   lander
     #   safir
+pyjwt[crypto]==2.6.0
+    # via gidgethub
 pypandoc==1.11
     # via lander
 python-dateutil==2.8.2
@@ -88,9 +102,9 @@ pyyaml==6.0
     #   -r requirements/main.in
     #   panflute
     #   uvicorn
-rfc3986[idna2008]==1.5.0
-    # via httpx
-safir==3.6.0
+redis==4.5.4
+    # via safir
+safir[redis]==4.0.0
     # via -r requirements/main.in
 six==1.16.0
     # via
@@ -106,24 +120,26 @@ sniffio==1.3.0
     #   httpx
 spherex-lander-plugin @ git+https://github.com/SPHEREx/spherex-lander-plugin.git@main
     # via -r requirements/main.in
-starlette==0.25.0
+starlette==0.26.1
     # via
     #   -r requirements/main.in
     #   fastapi
     #   safir
-structlog==22.3.0
+structlog==23.1.0
     # via safir
 typer==0.7.0
     # via lander
 typing-extensions==4.5.0
     # via pydantic
-uvicorn[standard]==0.20.0
+uritemplate==4.1.1
+    # via gidgethub
+uvicorn[standard]==0.21.1
     # via -r requirements/main.in
 uvloop==0.17.0
     # via uvicorn
-watchfiles==0.18.1
+watchfiles==0.19.0
     # via uvicorn
 webencodings==0.5.1
     # via bleach
-websockets==10.4
+websockets==11.0.2
     # via uvicorn

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ strict_equality = True
 warn_redundant_casts = True
 warn_unreachable = True
 warn_unused_ignores = True
+plugins =
+    pydantic.mypy
 
 [tool.pytest.ini_options]
 asyncio_mode = strict

--- a/src/spherexportal/config.py
+++ b/src/spherexportal/config.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
 
-from pydantic import BaseSettings, Field, FilePath, HttpUrl, SecretStr
+from pydantic import (
+    BaseSettings,
+    Field,
+    FilePath,
+    HttpUrl,
+    RedisDsn,
+    SecretStr,
+)
 
 __all__ = ["Config", "Profile", "LogLevel"]
 
@@ -40,7 +46,7 @@ class Config(BaseSettings):
     dataset_path: FilePath = Field(..., env="PORTAL_DATASET_PATH")
 
     ltd_api_url: HttpUrl = Field(
-        "https://docs-api.ipac.caltech.edu",
+        HttpUrl("https://docs-api.ipac.caltech.edu/", scheme="https"),
         description="Root URL of the LTD API server.",
         env="PORTAL_LTD_API_URL",
     )
@@ -57,7 +63,7 @@ class Config(BaseSettings):
         env="PORTAL_LTD_API_USERNAME",
     )
 
-    ltd_api_password: Optional[SecretStr] = Field(
+    ltd_api_password: SecretStr | None = Field(
         None,
         description="Password corresponding to ltd_api_username",
         env="PORTAL_LTD_API_PASSWORD",
@@ -72,13 +78,13 @@ class Config(BaseSettings):
         env="PORTAL_S3_REGION",
     )
 
-    aws_access_key_id: Optional[str] = Field(
+    aws_access_key_id: str | None = Field(
         None,
         description="AWS access key ID; for getting metadata objects from S3.",
         env="PORTAL_AWS_ACCESS_KEY_ID",
     )
 
-    aws_access_key_secret: Optional[SecretStr] = Field(
+    aws_access_key_secret: SecretStr | None = Field(
         None,
         description=(
             "AWS access key secret; for getting metadata objects from S3."
@@ -93,6 +99,12 @@ class Config(BaseSettings):
             "sources like LTD and S3"
         ),
         env="PORTAL_USE_MOCK_DATA",
+    )
+
+    redis_url: RedisDsn = Field(
+        RedisDsn("redis://localhost:6379/0", scheme="redis"),
+        env="PORTAL_REDIS_URL",
+        description="Redis database URL for caching project metadata.",
     )
 
 

--- a/src/spherexportal/dependencies/projects.py
+++ b/src/spherexportal/dependencies/projects.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from redis.asyncio import Redis
+
 from ..repositories.projects import ProjectRepository
 
 __all__ = ["projects_dependency"]
@@ -9,9 +11,14 @@ __all__ = ["projects_dependency"]
 
 class ProjectsDependency:
     def __init__(self) -> None:
-        self._repo = ProjectRepository()
+        self._repo: ProjectRepository | None = None
+
+    async def initialize(self, redis: Redis) -> None:
+        self._repo = await ProjectRepository.create(redis)
 
     async def __call__(self) -> ProjectRepository:
+        if self._repo is None:
+            raise RuntimeError("ProjectsDependency is not initialized")
         return self._repo
 
 

--- a/src/spherexportal/dependencies/redis.py
+++ b/src/spherexportal/dependencies/redis.py
@@ -1,0 +1,46 @@
+"""Redis dependency for FastAPI."""
+
+from typing import Optional
+
+from redis.asyncio import Redis
+
+__all__ = ["RedisDependency", "redis_dependency"]
+
+
+class RedisDependency:
+    """Provides an asyncio-based Redis client as a dependency.
+
+    Notes
+    -----
+    This dependency must be initialized in a start-up hook (`initialize`) and
+    closed in a shut down hook (`close`).
+    """
+
+    def __init__(self) -> None:
+        self.redis: Redis | None = None
+
+    async def initialize(
+        self, redis_url: str, password: Optional[str] = None
+    ) -> None:
+        self.redis = Redis.from_url(redis_url, password=password)
+
+    async def __call__(self) -> Redis:
+        """Returns the redis pool."""
+        if self.redis is None:
+            raise RuntimeError("RedisDependency is not initialized")
+        return self.redis
+
+    async def close(self) -> None:
+        """Close the open Redis pool.
+
+        Should be called from a shutdown hook to ensure that the Redis clients
+        are cleanly shut down and any pending writes are complete.
+        """
+        if self.redis:
+            await self.redis.close()
+            await self.redis.connection_pool.disconnect()
+            self.redis = None
+
+
+redis_dependency = RedisDependency()
+"""The dependency that will return the Redis pool."""

--- a/src/spherexportal/domain.py
+++ b/src/spherexportal/domain.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Generic, List, Optional, TypeVar
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -186,30 +185,3 @@ class SpherexTnDocument(SpherexDocument):
 
 class SpherexOpDocument(SpherexDocument):
     """A SPHEREx Operations Note, SSDC-OP."""
-
-
-T = TypeVar("T", bound="SpherexProject")
-
-
-@dataclass(kw_only=True)
-class SpherexCategory(Generic[T]):
-    """A collection of SpherexProject items for a specific category."""
-
-    projects: List[T] = field(default_factory=list)
-
-    def upsert(self, project: T) -> None:
-        """Append a new project or replace an existing project with the new
-        data.
-
-        Projects are assessed to be matching based on a``project_id`` and
-        ``organization_id``.
-        """
-        for i, existing_project in enumerate(self.projects):
-            if (existing_project.project_id == project.project_id) and (
-                existing_project.organization_id == project.organization_id
-            ):
-                self.projects[i] = project
-                return
-
-        # Only if there isn't a match
-        self.projects.append(project)

--- a/src/spherexportal/domain.py
+++ b/src/spherexportal/domain.py
@@ -6,145 +6,163 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Generic, List, Optional, TypeVar
 
+from pydantic import BaseModel, Field
 
-@dataclass(kw_only=True)
-class SpherexProject:
+approval_field = Field(
+    None, description="Approval information for the document."
+)
+
+
+class SpherexProject(BaseModel):
     """A generic SPHEREx documentation project hosted on
     spherex-docs.ipac.caltech.edu.
     """
 
-    url: str
-    """Root HTML URL."""
+    url: str = Field(..., description="Root HTML URL.")
 
-    title: str
-    """The title of the documentation project."""
+    title: str = Field(..., description="Title of the documentation project.")
 
-    project_id: str
-    """ID of the project in the LTD API."""
+    project_id: str = Field(
+        ..., description="ID of the project in the LTD API."
+    )
 
-    organization_id: str = "spherex"
-    """ID of the organization in the LTD API."""
+    organization_id: str = Field(
+        "spherex", description="ID of the organization in the LTD API."
+    )
 
 
-@dataclass(kw_only=True)
-class GitHubIssueCount:
+class GitHubIssueCount(BaseModel):
     """Summary info about GitHub issues."""
 
-    open_issue_count: int
+    open_issue_count: int = Field(
+        ..., description="Number of open GitHub issues."
+    )
 
-    open_pr_count: int
+    open_pr_count: int = Field(..., description="Number of open GitHub PRs.")
 
-    issue_url: str
+    issue_url: str = Field(
+        ..., description="Base URL of the GitHub issue tracker."
+    )
 
-    pr_url: str
+    pr_url: str = Field(..., description="Base URL of the GitHub PR tracker.")
 
 
-@dataclass(kw_only=True)
-class GitHubRelease:
+class GitHubRelease(BaseModel):
     """Summary of the latest GitHub release."""
 
-    tag: str
+    tag: str = Field(..., description="Git tag.")
     """Git tag."""
 
-    date_created: datetime
-    """Time (UTC) when the release was created."""
+    date_created: datetime = Field(
+        ..., description="Times (UTC) when the release was created."
+    )
 
 
-@dataclass(kw_only=True)
 class SpherexGitHubProject(SpherexProject):
     """A GitHub-based SPHEREx documentation project."""
 
-    github_url: str
-    """URL of the project's GitHub repository."""
+    github_url: str = Field(
+        ..., description="URL of the project's GitHub repo."
+    )
 
-    github_issues: GitHubIssueCount
-    """Summary info about open GitHub issues and PRs."""
+    github_issues: GitHubIssueCount = Field(
+        ..., description="Summary info about open GitHub issues and PRs."
+    )
 
-    latest_commit_datetime: datetime
-    """The datetime (with a UTC timezone) of the latest commit to the default
-    branch on GitHub.
-    """
+    latest_commit_datetime: datetime = Field(
+        ...,
+        description=(
+            "Datetime of the latest commit to the default branch (UTC)."
+        ),
+    )
 
-    github_release: Optional[GitHubRelease]
-    """Information about the current GitHub release, or None if a release
-    isn't available.
-    """
+    github_release: Optional[GitHubRelease] = Field(
+        None,
+        description=(
+            "Information about the latest GitHub release. None if a release "
+            "isn't available."
+        ),
+    )
 
 
-@dataclass(kw_only=True)
 class SpherexDocument(SpherexGitHubProject):
     """A general SPHEREx document."""
 
-    series: str
-    """The document series; typically the handle's prefix."""
+    series: str = Field(
+        ..., description="The document series; typically the handle's prefix."
+    )
 
-    handle: str
-    """The document's identifier."""
+    handle: str = Field(..., description="The document's handle.")
 
-    ssdc_author_name: str
-    """Name of the lead SSDC author."""
+    ssdc_author_name: str = Field(
+        ..., description="Name of the lead SSDC author."
+    )
 
 
-@dataclass(kw_only=True)
 class SpherexMsDocument(SpherexDocument):
     """A SPHEREx Module Specification, SSDC-MS."""
 
-    project_contact_name: str
+    project_contact_name: str = Field(
+        ..., description="Name of the project contact (SPHEREx POC)."
+    )
 
-    diagram_index: int
+    diagram_index: int = Field(..., description="The module's diagram index.")
 
-    pipeline_level: int
+    pipeline_level: int = Field(
+        ..., description="The module's pipeline level."
+    )
 
-    approval_str: Optional[str] = None
+    approval_str: Optional[str] = approval_field
 
-    difficulty: str
+    difficulty: str = Field(..., description="The module's difficulty level.")
 
     @property
     def diagram_ref(self) -> str:
+        """The displayable diagram reference for the module."""
         return f"L{self.pipeline_level}.{self.diagram_index}"
 
     @property
     def sortable_diagram_ref(self) -> str:
+        """The sortable diagram reference (zero-padded) for the module."""
         return f"L{self.pipeline_level}.{self.diagram_index:02d}"
 
 
-@dataclass(kw_only=True)
 class SpherexPmDocument(SpherexDocument):
     """A SPHEREx Project Management, SSDC-PM."""
 
-    approval_str: Optional[str] = None
+    approval_str: Optional[str] = approval_field
 
 
-@dataclass(kw_only=True)
 class SpherexIfDocument(SpherexDocument):
     """A SPHEREx Interface, SSDC-IF."""
 
-    approval_str: Optional[str] = None
+    approval_str: Optional[str] = approval_field
 
-    interface_partner_name: str
+    interface_partner_name: str = Field(
+        ..., description="Name of the interface partner (institution)."
+    )
 
 
-@dataclass(kw_only=True)
 class SpherexDpDocument(SpherexDocument):
     """A SPHEREx Interface, SSDC-DP."""
 
-    approval_str: Optional[str] = None
+    approval_str: Optional[str] = approval_field
 
 
-@dataclass(kw_only=True)
 class SpherexTrDocument(SpherexDocument):
     """A SPHEREx Test Report, SSDC-TR."""
 
-    approval_str: Optional[str] = None
+    approval_str: Optional[str] = approval_field
 
-    va_doors_id: Optional[str] = None
+    va_doors_id: Optional[str] = Field(None, description="VA DOORS ID.")
 
-    req_doors_id: Optional[str] = None
+    req_doors_id: Optional[str] = Field(None, description="REQ DOORS ID.")
 
-    ipac_jira_id: Optional[str] = None
+    ipac_jira_id: Optional[str] = Field(None, description="IPAC JIRA ID.")
 
     @property
     def has_verification_ids(self) -> bool:
+        """Flag indicating whether the document has any verification IDs."""
         return (
             (self.va_doors_id is not None)
             | (self.req_doors_id is not None)
@@ -153,18 +171,19 @@ class SpherexTrDocument(SpherexDocument):
 
     @property
     def ipac_jira_url(self) -> str:
+        """The URL of the IPAC JIRA ticket, or an empty string if none is
+        available.
+        """
         if self.ipac_jira_id:
             return f"https://jira.ipac.caltech.edu/browse/{self.ipac_jira_id}"
         else:
             return ""
 
 
-@dataclass(kw_only=True)
 class SpherexTnDocument(SpherexDocument):
     """A SPHEREx Technical Note, SSDC-TN."""
 
 
-@dataclass(kw_only=True)
 class SpherexOpDocument(SpherexDocument):
     """A SPHEREx Operations Note, SSDC-OP."""
 

--- a/src/spherexportal/pages/handlers.py
+++ b/src/spherexportal/pages/handlers.py
@@ -37,7 +37,7 @@ async def get_ssdc_ms(
 ) -> _TemplateResponse:
     context = {
         "current_path": "/ssdc-ms",
-        "category": projects_repo.ssdc_ms,
+        "projects": await projects_repo.ssdc_ms.get_all(),
         "request": request,
     }
     return templates.TemplateResponse("ssdc-ms.html.jinja", context)
@@ -50,7 +50,7 @@ async def get_ssdc_pm(
 ) -> _TemplateResponse:
     context = {
         "current_path": "/ssdc-pm",
-        "category": projects_repo.ssdc_pm,
+        "projects": await projects_repo.ssdc_pm.get_all(),
         "request": request,
     }
     return templates.TemplateResponse("ssdc-pm.html.jinja", context)
@@ -63,7 +63,7 @@ async def get_ssdc_if(
 ) -> _TemplateResponse:
     context = {
         "current_path": "/ssdc-if",
-        "category": projects_repo.ssdc_if,
+        "projects": await projects_repo.ssdc_if.get_all(),
         "request": request,
     }
     return templates.TemplateResponse("ssdc-if.html.jinja", context)
@@ -76,7 +76,7 @@ async def get_ssdc_dp(
 ) -> _TemplateResponse:
     context = {
         "current_path": "/ssdc-dp",
-        "category": projects_repo.ssdc_dp,
+        "projects": await projects_repo.ssdc_dp.get_all(),
         "request": request,
     }
     return templates.TemplateResponse("ssdc-dp.html.jinja", context)
@@ -89,7 +89,7 @@ async def get_ssdc_tr(
 ) -> _TemplateResponse:
     context = {
         "current_path": "/ssdc-tr",
-        "category": projects_repo.ssdc_tr,
+        "projects": await projects_repo.ssdc_tr.get_all(),
         "request": request,
     }
     return templates.TemplateResponse("ssdc-tr.html.jinja", context)
@@ -102,7 +102,7 @@ async def get_ssdc_tn(
 ) -> _TemplateResponse:
     context = {
         "current_path": "/ssdc-tn",
-        "category": projects_repo.ssdc_tn,
+        "projects": await projects_repo.ssdc_tn.get_all(),
         "request": request,
     }
     return templates.TemplateResponse("ssdc-tn.html.jinja", context)
@@ -115,7 +115,7 @@ async def get_ssdc_op(
 ) -> _TemplateResponse:
     context = {
         "current_path": "/ssdc-op",
-        "category": projects_repo.ssdc_op,
+        "projects": await projects_repo.ssdc_op.get_all(),
         "request": request,
     }
     return templates.TemplateResponse("ssdc-op.html.jinja", context)

--- a/src/spherexportal/pages/templates/ssdc-dp.html.jinja
+++ b/src/spherexportal/pages/templates/ssdc-dp.html.jinja
@@ -5,7 +5,7 @@
 {% block content %}
 <h1>Data Products (SSDC-DP)</h1>
 
-{% if category.projects %}
+{% if projects %}
 <table class="sortable asc spherex-project-table">
   <thead>
     <tr>
@@ -16,7 +16,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for doc in category.projects|sort(attribute="handle") %}
+    {% for doc in projects|sort(attribute="handle") %}
     <tr>
       <td><a href="{{ doc.url }}">{{ doc.handle }}</a></td>
       <td><a href="{{ doc.url }}">{{ doc.title }}</a></td>

--- a/src/spherexportal/pages/templates/ssdc-if.html.jinja
+++ b/src/spherexportal/pages/templates/ssdc-if.html.jinja
@@ -7,7 +7,7 @@
 
 <p>Includes OIAs and ICDs that are not already in the JPL document system.</p>
 
-{% if category.projects %}
+{% if projects %}
 <table class="sortable asc spherex-project-table">
     <thead>
         <tr>
@@ -19,7 +19,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for doc in category.projects|sort(attribute="handle") %}
+        {% for doc in projects|sort(attribute="handle") %}
         <tr>
             <td><a href="{{ doc.url }}">{{ doc.handle }}</a></td>
             <td><a href="{{ doc.url }}">{{ doc.title }}</a></td>

--- a/src/spherexportal/pages/templates/ssdc-ms.html.jinja
+++ b/src/spherexportal/pages/templates/ssdc-ms.html.jinja
@@ -5,12 +5,11 @@
 {% block content %}
 <h1>Module Specifications (SSDC-MS)</h1>
 
-<p><a
-    href="https://collaboration.ipac.caltech.edu/pages/viewpage.action?spaceKey=SPHEREx&title=Pipeline+Module+Descriptions">Pipeline
+<p><a href="https://collaboration.ipac.caltech.edu/pages/viewpage.action?spaceKey=SPHEREx&title=Pipeline+Module+Descriptions">Pipeline
     diagram →</a>
 </p>
 
-{% if category.projects %}
+{% if projects %}
 <table class="sortable asc spherex-project-table">
   <thead>
     <tr>
@@ -24,7 +23,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for doc in category.projects|sort(attribute="sortable_diagram_ref") %}
+    {% for doc in projects|sort(attribute="sortable_diagram_ref") %}
     <tr>
       <td><a href="{{ doc.url }}">{{ doc.handle }}</a></td>
       <td><a href="{{ doc.url }}">{{ doc.title }}</a></td>

--- a/src/spherexportal/pages/templates/ssdc-op.html.jinja
+++ b/src/spherexportal/pages/templates/ssdc-op.html.jinja
@@ -5,7 +5,7 @@
 {% block content %}
 <h1>Operations Procedures (SSDC-OP)</h1>
 
-{% if category.projects %}
+{% if projects %}
 <table class="sortable asc spherex-project-table">
   <thead>
     <tr>
@@ -16,7 +16,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for doc in category.projects|sort(attribute="handle") %}
+    {% for doc in projects|sort(attribute="handle") %}
     <tr>
       <td><a href="{{ doc.url }}">{{ doc.handle }}</a></td>
       <td><a href="{{ doc.url }}">{{ doc.title }}</a></td>

--- a/src/spherexportal/pages/templates/ssdc-pm.html.jinja
+++ b/src/spherexportal/pages/templates/ssdc-pm.html.jinja
@@ -5,7 +5,7 @@
 {% block content %}
 <h1>Project Management (SSDC-PM)</h1>
 
-{% if category.projects %}
+{% if projects %}
 <table class="sortable asc spherex-project-table">
     <thead>
         <tr>
@@ -16,7 +16,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for doc in category.projects|sort(attribute="handle") %}
+        {% for doc in projects|sort(attribute="handle") %}
         <tr>
             <td><a href="{{ doc.url }}">{{ doc.handle }}</a></td>
             <td><a href="{{ doc.url }}">{{ doc.title }}</a></td>

--- a/src/spherexportal/pages/templates/ssdc-tn.html.jinja
+++ b/src/spherexportal/pages/templates/ssdc-tn.html.jinja
@@ -5,7 +5,7 @@
 {% block content %}
 <h1>SPHEREx Technical Notes (SSDC-TN)</h1>
 
-{% if category.projects %}
+{% if projects %}
 <table class="sortable asc spherex-project-table">
   <thead>
     <tr>
@@ -15,7 +15,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for doc in category.projects|sort(attribute="handle") %}
+    {% for doc in projects|sort(attribute="handle") %}
     <tr>
       <td><a href="{{ doc.url }}">{{ doc.handle }}</a></td>
       <td><a href="{{ doc.url }}">{{ doc.title }}</a></td>

--- a/src/spherexportal/pages/templates/ssdc-tr.html.jinja
+++ b/src/spherexportal/pages/templates/ssdc-tr.html.jinja
@@ -5,7 +5,7 @@
 {% block content %}
 <h1>Test Reports (SSDC-TR)</h1>
 
-{% if category.projects %}
+{% if projects %}
 <table class="sortable asc spherex-project-table">
   <thead>
     <tr>
@@ -17,7 +17,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for doc in category.projects|sort(attribute="handle") %}
+    {% for doc in projects|sort(attribute="handle") %}
     <tr>
       <td><a href="{{ doc.url }}">{{ doc.handle }}</a></td>
       <td><a href="{{ doc.url }}">{{ doc.title }}</a></td>

--- a/src/spherexportal/repositories/mockdata.py
+++ b/src/spherexportal/repositories/mockdata.py
@@ -13,7 +13,6 @@ from pydantic import AnyHttpUrl, BaseModel, Field
 from ..domain import (
     GitHubIssueCount,
     GitHubRelease,
-    SpherexCategory,
     SpherexDpDocument,
     SpherexIfDocument,
     SpherexMsDocument,
@@ -279,48 +278,6 @@ class MockDataModel(BaseModel):
         data = yaml.safe_load(path.read_text())
         return cls.parse_obj(data)
 
-    @property
-    def ssdc_ms_projects(self) -> SpherexCategory[SpherexMsDocument]:
-        return SpherexCategory(
-            projects=[doc.domain_model for doc in self.ssdc_ms]
-        )
-
-    @property
-    def ssdc_pm_projects(self) -> SpherexCategory[SpherexPmDocument]:
-        return SpherexCategory(
-            projects=[doc.domain_model for doc in self.ssdc_pm]
-        )
-
-    @property
-    def ssdc_if_projects(self) -> SpherexCategory[SpherexIfDocument]:
-        return SpherexCategory(
-            projects=[doc.domain_model for doc in self.ssdc_if]
-        )
-
-    @property
-    def ssdc_dp_projects(self) -> SpherexCategory[SpherexDpDocument]:
-        return SpherexCategory(
-            projects=[doc.domain_model for doc in self.ssdc_dp]
-        )
-
-    @property
-    def ssdc_tr_projects(self) -> SpherexCategory[SpherexTrDocument]:
-        return SpherexCategory(
-            projects=[doc.domain_model for doc in self.ssdc_tr]
-        )
-
-    @property
-    def ssdc_tn_projects(self) -> SpherexCategory[SpherexTnDocument]:
-        return SpherexCategory(
-            projects=[doc.domain_model for doc in self.ssdc_tn]
-        )
-
-    @property
-    def ssdc_op_projects(self) -> SpherexCategory[SpherexOpDocument]:
-        return SpherexCategory(
-            projects=[doc.domain_model for doc in self.ssdc_op]
-        )
-
 
 class MockDataRepository:
     """A repository that loads mock project data from a YAML file for testing.
@@ -342,12 +299,27 @@ class MockDataRepository:
         data = MockDataModel.from_yaml(path)
         return cls(data)
 
-    def bootstrap_project_repository(self, repo: ProjectRepository) -> None:
+    async def bootstrap_project_repository(
+        self, repo: ProjectRepository
+    ) -> None:
         """Add mock data to the `ProjectRepository`."""
-        repo.ssdc_ms = self._data.ssdc_ms_projects
-        repo.ssdc_pm = self._data.ssdc_pm_projects
-        repo.ssdc_if = self._data.ssdc_if_projects
-        repo.ssdc_dp = self._data.ssdc_dp_projects
-        repo.ssdc_tr = self._data.ssdc_tr_projects
-        repo.ssdc_tn = self._data.ssdc_tn_projects
-        repo.ssdc_op = self._data.ssdc_op_projects
+        for ms_doc in self._data.ssdc_ms:
+            await repo.ssdc_ms.upsert(ms_doc.domain_model)
+
+        for pm_doc in self._data.ssdc_pm:
+            await repo.ssdc_pm.upsert(pm_doc.domain_model)
+
+        for if_doc in self._data.ssdc_if:
+            await repo.ssdc_if.upsert(if_doc.domain_model)
+
+        for dp_doc in self._data.ssdc_dp:
+            await repo.ssdc_dp.upsert(dp_doc.domain_model)
+
+        for tr_doc in self._data.ssdc_tr:
+            await repo.ssdc_tr.upsert(tr_doc.domain_model)
+
+        for tn_doc in self._data.ssdc_tn:
+            await repo.ssdc_tn.upsert(tn_doc.domain_model)
+
+        for op_doc in self._data.ssdc_op:
+            await repo.ssdc_op.upsert(op_doc.domain_model)

--- a/src/spherexportal/repositories/projects.py
+++ b/src/spherexportal/repositories/projects.py
@@ -2,18 +2,50 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from typing import Self, TypeVar
+
+from redis.asyncio import Redis
+from safir.redis import PydanticRedisStorage
 
 from ..domain import (
-    SpherexCategory,
     SpherexDpDocument,
     SpherexIfDocument,
     SpherexMsDocument,
     SpherexOpDocument,
     SpherexPmDocument,
+    SpherexProject,
     SpherexTnDocument,
     SpherexTrDocument,
 )
+
+T = TypeVar("T", bound="SpherexProject")
+
+
+class SpherexProjectStore(PydanticRedisStorage[T]):
+    """A Redis-backed store for SPHEREx projects in a specific category."""
+
+    def __init__(self, project_cls: type[T], redis: Redis, key_prefix: str):
+        super().__init__(
+            datatype=project_cls, redis=redis, key_prefix=key_prefix
+        )
+
+    async def get_all(self) -> list[T]:
+        """Get all projects, sorted by ID (key)."""
+        keys = [m async for m in self.scan("*")]
+        keys.sort()
+        projects: list[T] = []
+        for k in keys:
+            project = await self.get(k)
+            if project:
+                projects.append(project)
+        return projects
+
+    async def upsert(self, project: T) -> None:
+        """Append a new project or replace an existing project with the new
+        data.
+        """
+        await self.store(project.project_id, project)
 
 
 @dataclass(kw_only=True)
@@ -22,30 +54,49 @@ class ProjectRepository:
     project categories for fast access.
     """
 
-    ssdc_ms: SpherexCategory[SpherexMsDocument] = field(
-        default_factory=SpherexCategory
-    )
+    ssdc_ms: SpherexProjectStore[SpherexMsDocument]
 
-    ssdc_pm: SpherexCategory[SpherexPmDocument] = field(
-        default_factory=SpherexCategory
-    )
+    ssdc_pm: SpherexProjectStore[SpherexPmDocument]
 
-    ssdc_if: SpherexCategory[SpherexIfDocument] = field(
-        default_factory=SpherexCategory
-    )
+    ssdc_if: SpherexProjectStore[SpherexIfDocument]
 
-    ssdc_dp: SpherexCategory[SpherexDpDocument] = field(
-        default_factory=SpherexCategory
-    )
+    ssdc_dp: SpherexProjectStore[SpherexDpDocument]
 
-    ssdc_tr: SpherexCategory[SpherexTrDocument] = field(
-        default_factory=SpherexCategory
-    )
+    ssdc_tr: SpherexProjectStore[SpherexTrDocument]
 
-    ssdc_tn: SpherexCategory[SpherexTnDocument] = field(
-        default_factory=SpherexCategory
-    )
+    ssdc_tn: SpherexProjectStore[SpherexTnDocument]
 
-    ssdc_op: SpherexCategory[SpherexOpDocument] = field(
-        default_factory=SpherexCategory
-    )
+    ssdc_op: SpherexProjectStore[SpherexOpDocument]
+
+    @classmethod
+    async def create(cls, redis: Redis) -> Self:
+        ms_store = SpherexProjectStore(
+            SpherexMsDocument, redis, key_prefix="ssdc_ms:"
+        )
+        pm_store = SpherexProjectStore(
+            SpherexPmDocument, redis, key_prefix="ssdc_pm:"
+        )
+        if_store = SpherexProjectStore(
+            SpherexIfDocument, redis, key_prefix="ssdc_if:"
+        )
+        dp_store = SpherexProjectStore(
+            SpherexDpDocument, redis, key_prefix="ssdc_dp:"
+        )
+        tr_store = SpherexProjectStore(
+            SpherexTrDocument, redis, key_prefix="ssdc_tr:"
+        )
+        tn_store = SpherexProjectStore(
+            SpherexTnDocument, redis, key_prefix="ssdc_tn:"
+        )
+        op_store = SpherexProjectStore(
+            SpherexOpDocument, redis, key_prefix="ssdc_op:"
+        )
+        return cls(
+            ssdc_ms=ms_store,
+            ssdc_pm=pm_store,
+            ssdc_if=if_store,
+            ssdc_dp=dp_store,
+            ssdc_tr=tr_store,
+            ssdc_tn=tn_store,
+            ssdc_op=op_store,
+        )

--- a/src/spherexportal/services/projectservice.py
+++ b/src/spherexportal/services/projectservice.py
@@ -62,7 +62,7 @@ class ProjectService:
 
     async def bootstrap_mock_repo(self) -> None:
         mockdata_repo = MockDataRepository.load_builtin_data()
-        mockdata_repo.bootstrap_project_repository(self._repo)
+        await mockdata_repo.bootstrap_project_repository(self._repo)
 
     async def bootstrap_from_api(self) -> None:
         """Bootstrap the project repository using data from the LTD API."""
@@ -117,7 +117,8 @@ class ProjectService:
                     )
             except MetadataError as e:
                 self._logger.warning(
-                    f"Could ingest metadata for {project.slug}", details=str(e)
+                    f"Could not ingest metadata for {project.slug}",
+                    details=str(e),
                 )
                 continue
 
@@ -185,7 +186,7 @@ class ProjectService:
             ),
             difficulty=str(lander_metadata.difficulty),
         )
-        self._repo.ssdc_ms.upsert(domain_model)
+        await self._repo.ssdc_ms.upsert(domain_model)
 
     async def _ingest_ssdc_pm(
         self,
@@ -218,7 +219,7 @@ class ProjectService:
                 lander_metadata.approval
             ),
         )
-        self._repo.ssdc_pm.upsert(domain_model)
+        await self._repo.ssdc_pm.upsert(domain_model)
 
     async def _ingest_ssdc_if(
         self,
@@ -252,7 +253,7 @@ class ProjectService:
             ),
             interface_partner_name=lander_metadata.interface_partner,
         )
-        self._repo.ssdc_if.upsert(domain_model)
+        await self._repo.ssdc_if.upsert(domain_model)
 
     async def _ingest_ssdc_dp(
         self,
@@ -285,7 +286,7 @@ class ProjectService:
                 lander_metadata.approval
             ),
         )
-        self._repo.ssdc_dp.upsert(domain_model)
+        await self._repo.ssdc_dp.upsert(domain_model)
 
     async def _ingest_ssdc_tr(
         self,
@@ -321,7 +322,7 @@ class ProjectService:
             req_doors_id=lander_metadata.req_doors_id,
             ipac_jira_id=lander_metadata.ipac_jira_id,
         )
-        self._repo.ssdc_tr.upsert(domain_model)
+        await self._repo.ssdc_tr.upsert(domain_model)
 
     async def _ingest_ssdc_tn(
         self,
@@ -351,7 +352,7 @@ class ProjectService:
             latest_commit_datetime=project.default_edition.date_rebuilt,
             ssdc_author_name=self._get_ssdc_lead(lander_metadata),
         )
-        self._repo.ssdc_tn.upsert(domain_model)
+        await self._repo.ssdc_tn.upsert(domain_model)
 
     async def _ingest_ssdc_op(
         self,
@@ -381,4 +382,4 @@ class ProjectService:
             latest_commit_datetime=project.default_edition.date_rebuilt,
             ssdc_author_name=self._get_ssdc_lead(lander_metadata),
         )
-        self._repo.ssdc_op.upsert(domain_model)
+        await self._repo.ssdc_op.upsert(domain_model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest_asyncio
+import redis.asyncio as redis
 from asgi_lifespan import LifespanManager
 from httpx import AsyncClient
 
@@ -14,6 +15,18 @@ if TYPE_CHECKING:
     from typing import AsyncIterator
 
     from fastapi import FastAPI
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator[redis.Redis]:
+    """A Redis client for testing.
+
+    This fixture connects to the Redis server that runs via tox-docker.
+    """
+    client: redis.Redis = redis.Redis(host="localhost", port=6379, db=0)
+    yield client
+
+    await client.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import pytest
+import redis.asyncio as redis
+
 from spherexportal.repositories.mockdata import MockDataRepository
 from spherexportal.repositories.projects import ProjectRepository
 
 
-def test_loading_mock_data() -> None:
-    project_repo = ProjectRepository()
+@pytest.mark.asyncio
+async def test_loading_mock_data(redis_client: redis.Redis) -> None:
+    project_repo = await ProjectRepository.create(redis_client)
     mock_repo = MockDataRepository.load_builtin_data()
-    mock_repo.bootstrap_project_repository(project_repo)
+    await mock_repo.bootstrap_project_repository(project_repo)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,21 @@
 envlist = py,coverage-report,typing,lint
 isolated_build = True
 
+[docker:redis]
+image = redis:latest
+ports =
+    6379:6379/tcp
+healthcheck_cmd =
+    redis-cli ping
+healthcheck_timeout = 1
+healthcheck_retries = 30
+healthcheck_interval = 1
+healthcheck_start_period = 1
+
 [testenv]
 description = Run pytest against {envname}.
+docker =
+    redis
 deps =
     -r{toxinidir}/requirements/main.txt
     -r{toxinidir}/requirements/dev.txt


### PR DESCRIPTION
This change switches the ProjectRepository to now store domain models for documentation projects in Redis, rather than in memory. This is done so that implement asynchronous updates to the data (via GitHub webhooks or periodic refreshes).

This is principally done through the PydanticRedisStorage class from Safir (https://safir.lsst.io/user-guide/pydantic-redis.html). All domain objects are now Pydantic objects rather than dataclasses to enable data serialization to Redis.

Because the data is now requested asynchronously, there's a small change to how the data is referenced in the Jinja templates, but otherwise the update is straightforward.
