### PR TITLE
Set up arq queue service to periodically refresh project metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v3.0.0-alpha.6'
+    rev: 'v3.0.3'
     hooks:
       - id: prettier
         types: [css, javascript]
@@ -19,11 +19,11 @@ repos:
           - tomli
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8

--- a/manifests/base/configmap.yaml
+++ b/manifests/base/configmap.yaml
@@ -13,3 +13,5 @@ data:
   SAFIR_LOG_LEVEL: "INFO"
   PORTAL_DATASET_PATH: "/opt/spherex-doc-portal/dataset/dataset.yaml"
   PORTAL_REDIS_URL: "redis://redis:6379/0"
+  PORTAL_ARQ_REDIS_URL: "redis://redis:6379/1"
+  PORTAL_ARQ_MODE: "production"

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - configmap.yaml
   - dataset-configmap.yaml
   - deployment.yaml
+  - worker.yaml
   - service.yaml

--- a/manifests/base/worker.yaml
+++ b/manifests/base/worker.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "spherex-doc-portal-worker"
+  labels:
+    app.kubernetes.io/name: "spherex-doc-portal-worker"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "spherex-doc-portal-worker"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "spherex-doc-portal-worker"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: app
+          imagePullPolicy: "IfNotPresent"
+          # Use images field in a Kustomization to set/update image tag
+          image: "ghcr.io/spherex/spherex-doc-portal"
+          envFrom:
+            - configMapRef:
+                name: "spherex-doc-portal"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "dataset"
+              mountPath: "/opt/spherex-doc-portal/dataset/"
+              readOnly: true
+          command: ["arq"]
+          args: ["spherexportal.worker.main.WorkerSettings"]
+          livenessProbe:
+            exec:
+              command:
+                - "arq"
+                - "--check"
+                - "spherexportal.worker.main.WorkerSettings"
+            initialDelaySeconds: 360
+            periodSeconds: 15
+      volumes:
+        - name: "dataset"
+          configMap:
+            name: "spherex-portal-dataset"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
-anyio==3.6.2
+anyio==3.7.1
     # via
     #   -c requirements/main.txt
     #   httpcore
 asgi-lifespan==2.1.0
     # via -r requirements/dev.in
-certifi==2022.12.7
+certifi==2023.7.22
     # via
     #   -c requirements/main.txt
     #   httpcore
@@ -19,34 +19,34 @@ cffi==1.15.1
     # via
     #   -c requirements/main.txt
     #   cryptography
-cfgv==3.3.1
+cfgv==3.4.0
     # via pre-commit
-coverage[toml]==7.2.3
+coverage[toml]==7.3.1
     # via
     #   -r requirements/dev.in
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.3
     # via
     #   -c requirements/main.txt
     #   types-pyopenssl
     #   types-redis
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
-filelock==3.12.0
+filelock==3.12.3
     # via virtualenv
 h11==0.14.0
     # via
     #   -c requirements/main.txt
     #   httpcore
-httpcore==0.17.0
+httpcore==0.18.0
     # via
     #   -c requirements/main.txt
     #   httpx
-httpx==0.24.0
+httpx==0.25.0
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
-identify==2.5.22
+identify==2.5.28
     # via pre-commit
 idna==3.4
     # via
@@ -55,34 +55,34 @@ idna==3.4
     #   httpx
 iniconfig==2.0.0
     # via pytest
-mypy==1.2.0
+mypy==1.5.1
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via mypy
-nodeenv==1.7.0
+nodeenv==1.8.0
     # via pre-commit
 packaging==23.1
     # via pytest
-platformdirs==3.2.0
+platformdirs==3.10.0
     # via virtualenv
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-pre-commit==3.2.2
+pre-commit==3.4.0
     # via -r requirements/dev.in
 pycparser==2.21
     # via
     #   -c requirements/main.txt
     #   cffi
-pytest==7.3.1
+pytest==7.4.2
     # via
     #   -r requirements/dev.in
     #   pytest-asyncio
     #   pytest-cov
-pytest-asyncio==0.21.0
+pytest-asyncio==0.21.1
     # via -r requirements/dev.in
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/dev.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -c requirements/main.txt
     #   pre-commit
@@ -93,19 +93,19 @@ sniffio==1.3.0
     #   asgi-lifespan
     #   httpcore
     #   httpx
-types-cachetools==5.3.0.5
+types-cachetools==5.3.0.6
     # via -r requirements/dev.in
-types-pyopenssl==23.1.0.2
+types-pyopenssl==23.2.0.2
     # via types-redis
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.11
     # via -r requirements/dev.in
-types-redis==4.5.4.1
+types-redis==4.6.0.5
     # via -r requirements/dev.in
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
     #   -c requirements/main.txt
     #   mypy
-virtualenv==20.22.0
+virtualenv==20.24.5
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -11,7 +11,7 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir[redis]
+safir[arq,redis]
 pydantic
 PyYAML
 Jinja2

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -11,12 +11,12 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir[arq,redis]
-pydantic
+safir[arq,redis] < 5.0.0
+pydantic < 2.0.0
 PyYAML
 Jinja2
 cachetools
 asyncache
 httpx
 aws-request-signer
-git+https://github.com/SPHEREx/spherex-lander-plugin.git@main#egg=spherex-lander-plugin
+spherex-lander-plugin @ git+https://github.com/SPHEREx/spherex-lander-plugin.git@main

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -9,6 +9,8 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
+arq==0.25.0
+    # via safir
 async-timeout==4.0.2
     # via redis
 asyncache==0.3.1
@@ -31,6 +33,7 @@ cffi==1.15.1
     # via cryptography
 click==8.1.3
     # via
+    #   arq
     #   panflute
     #   typer
     #   uvicorn
@@ -56,6 +59,8 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+hiredis==2.2.2
+    # via redis
 httpcore==0.17.0
     # via httpx
 httptools==0.5.0
@@ -102,9 +107,11 @@ pyyaml==6.0
     #   -r requirements/main.in
     #   panflute
     #   uvicorn
-redis==4.5.4
-    # via safir
-safir[redis]==4.0.0
+redis[hiredis]==4.5.4
+    # via
+    #   arq
+    #   safir
+safir[arq,redis]==4.0.0
     # via -r requirements/main.in
 six==1.16.0
     # via
@@ -130,7 +137,9 @@ structlog==23.1.0
 typer==0.7.0
     # via lander
 typing-extensions==4.5.0
-    # via pydantic
+    # via
+    #   arq
+    #   pydantic
 uritemplate==4.1.1
     # via gidgethub
 uvicorn[standard]==0.21.1

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,15 +4,14 @@
 #
 #    pip-compile --output-file=requirements/main.txt requirements/main.in
 #
-anyio==3.6.2
+anyio==3.7.1
     # via
+    #   fastapi
     #   httpcore
     #   starlette
     #   watchfiles
 arq==0.25.0
     # via safir
-async-timeout==4.0.2
-    # via redis
 asyncache==0.3.1
     # via -r requirements/main.in
 aws-request-signer==1.2.0
@@ -21,51 +20,52 @@ base32-lib==1.0.2
     # via lander
 bleach==6.0.0
     # via lander
-cachetools==5.3.0
+cachetools==5.3.1
     # via
     #   -r requirements/main.in
     #   asyncache
-certifi==2022.12.7
+certifi==2023.7.22
     # via
     #   httpcore
     #   httpx
 cffi==1.15.1
     # via cryptography
-click==8.1.3
+click==8.1.7
     # via
     #   arq
     #   panflute
+    #   safir
     #   typer
     #   uvicorn
-cryptography==40.0.2
+cryptography==41.0.3
     # via
     #   pyjwt
     #   safir
-dnspython==2.3.0
+dnspython==2.4.2
     # via email-validator
 email-validator==2.0.0.post2
     # via lander
-fastapi==0.95.1
+fastapi==0.103.1
     # via
     #   -r requirements/main.in
     #   safir
-gidgethub==5.2.1
+gidgethub==5.3.0
     # via safir
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.36
     # via lander
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-hiredis==2.2.2
+hiredis==2.2.3
     # via redis
-httpcore==0.17.0
+httpcore==0.18.0
     # via httpx
-httptools==0.5.0
+httptools==0.6.0
     # via uvicorn
-httpx==0.24.0
+httpx==0.25.0
     # via
     #   -r requirements/main.in
     #   safir
@@ -78,21 +78,21 @@ jinja2==3.1.2
     # via
     #   -r requirements/main.in
     #   lander
-lander==2.0.0a7
+lander==2.0.0a8
     # via spherex-lander-plugin
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 panflute==2.3.0
     # via lander
 pycparser==2.21
     # via cffi
-pydantic==1.10.7
+pydantic==1.10.12
     # via
     #   -r requirements/main.in
     #   fastapi
     #   lander
     #   safir
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.8.0
     # via gidgethub
 pypandoc==1.11
     # via lander
@@ -102,16 +102,16 @@ python-dateutil==2.8.2
     #   spherex-lander-plugin
 python-dotenv==1.0.0
     # via uvicorn
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/main.in
     #   panflute
     #   uvicorn
-redis[hiredis]==4.5.4
+redis[hiredis]==5.0.0
     # via
     #   arq
     #   safir
-safir[arq,redis]==4.0.0
+safir[arq,redis]==4.4.0
     # via -r requirements/main.in
 six==1.16.0
     # via
@@ -127,28 +127,30 @@ sniffio==1.3.0
     #   httpx
 spherex-lander-plugin @ git+https://github.com/SPHEREx/spherex-lander-plugin.git@main
     # via -r requirements/main.in
-starlette==0.26.1
+starlette==0.27.0
     # via
     #   -r requirements/main.in
     #   fastapi
     #   safir
 structlog==23.1.0
     # via safir
-typer==0.7.0
+typer==0.9.0
     # via lander
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
     #   arq
+    #   fastapi
     #   pydantic
+    #   typer
 uritemplate==4.1.1
     # via gidgethub
-uvicorn[standard]==0.21.1
+uvicorn[standard]==0.23.2
     # via -r requirements/main.in
 uvloop==0.17.0
     # via uvicorn
-watchfiles==0.19.0
+watchfiles==0.20.0
     # via uvicorn
 webencodings==0.5.1
     # via bleach
-websockets==11.0.2
+websockets==11.0.3
     # via uvicorn

--- a/src/spherexportal/worker/functions/__init__.py
+++ b/src/spherexportal/worker/functions/__init__.py
@@ -1,0 +1,3 @@
+from .refresh import refresh_projects
+
+__all__ = ["refresh_projects"]

--- a/src/spherexportal/worker/functions/refresh.py
+++ b/src/spherexportal/worker/functions/refresh.py
@@ -4,8 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..servicefactory import create_project_service
+
 
 async def refresh_projects(ctx: dict[Any, Any]) -> None:
     """Refresh the cache of project data in Redis."""
     logger = ctx["logger"].bind(task="refresh_projects")
     logger.info("Starting refresh of project data")
+
+    project_service = await create_project_service(logger=logger)
+
+    # The bootstrap project refreshes the cache of project data for all
+    # projects registered with the LTD API.
+    await project_service.bootstrap_from_api()
+
+    logger.info("Finished refresh of project data")

--- a/src/spherexportal/worker/functions/refresh.py
+++ b/src/spherexportal/worker/functions/refresh.py
@@ -1,0 +1,11 @@
+"""Arq task for refreshing the cache of project data in Redis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def refresh_projects(ctx: dict[Any, Any]) -> None:
+    """Refresh the cache of project data in Redis."""
+    logger = ctx["logger"].bind(task="refresh_projects")
+    logger.info("Starting refresh of project data")

--- a/src/spherexportal/worker/main.py
+++ b/src/spherexportal/worker/main.py
@@ -1,0 +1,71 @@
+"""Configuration for the Arq-based worker process."""
+
+import uuid
+from typing import Any
+
+import httpx
+import structlog
+from safir.logging import configure_logging
+
+from spherexportal.config import config
+from spherexportal.dependencies.redis import redis_dependency
+
+from .functions import refresh_projects
+
+
+async def startup(ctx: dict[Any, Any]) -> None:
+    """Runs during working start-up to set up the worker context."""
+    configure_logging(
+        profile=config.profile,
+        log_level=config.log_level,
+        name="timessquare",
+    )
+    logger = structlog.get_logger(config.logger_name)
+    # The instance key uniquely identifies this worker in logs
+    instance_key = uuid.uuid4().hex
+    logger = logger.bind(worker_instance=instance_key)
+
+    logger.info("Starting up worker")
+
+    http_client = httpx.AsyncClient()
+    ctx["http_client"] = http_client
+
+    ctx["logger"] = logger
+    logger.info("Start up complete")
+
+    # Set up FastAPI dependencies; we can use them "manually" with
+    # arq to provide resources similarly to FastAPI endpoints
+    await redis_dependency.initialize(config.redis_url)
+
+
+async def shutdown(ctx: dict[Any, Any]) -> None:
+    """Runs during worker shut-down to resources."""
+    if "logger" in ctx.keys():
+        logger = ctx["logger"]
+    else:
+        logger = structlog.get_logger(config.logger_name)
+    logger.info("Running worker shutdown.")
+
+    await redis_dependency.close()
+
+    try:
+        await ctx["http_client"].aclose()
+    except Exception as e:
+        logger.warning("Issue closing the http_client: %s", str(e))
+
+    logger.info("Worker shutdown complete.")
+
+
+class WorkerSettings:
+    """Configuration for a Times Square arq worker.
+
+    See `arq.worker.Worker` for details on these attributes.
+    """
+
+    functions = [refresh_projects]
+
+    redis_settings = config.arq_redis_settings
+
+    on_startup = startup
+
+    on_shutdown = shutdown

--- a/src/spherexportal/worker/servicefactory.py
+++ b/src/spherexportal/worker/servicefactory.py
@@ -1,0 +1,22 @@
+"""Create services for the worker."""
+
+
+import httpx
+from structlog.stdlib import BoundLogger
+
+from spherexportal.dependencies.projects import projects_dependency
+from spherexportal.dependencies.redis import redis_dependency
+from spherexportal.services.projectservice import ProjectService
+
+
+async def create_project_service(*, logger: BoundLogger) -> ProjectService:
+    """Create a project service."""
+    redis = await redis_dependency()
+    await projects_dependency.initialize(redis)
+    projects_repo = await projects_dependency()
+
+    http_client = httpx.AsyncClient()
+
+    return ProjectService(
+        repo=projects_repo, logger=logger, http_client=http_client
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ setenv =
     SAFIR_PROFILE=development
     SAFIR_LOG_LEVEL=DEBUG
     PORTAL_DATASET_PATH={toxinidir}/tests/dataset.example.yaml
+    PORTAL_ARQ_MODE = test
 commands =
     pytest --cov=spherexportal --cov-branch --cov-report= {posargs}
 


### PR DESCRIPTION
This PR sets up an Arq (asyncio-based redis queue) queue. The first application of this queue is to set up a "cron" job that periodically refreshes the project metadata by re-running the bootstrap service. This is made possible by #34 that moves metadata storage into Redis.