### PR TITLE
Ensure that all datetimes in domain models are UTC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
-          tox-envs: 'lint,typing,py,coverage-report'
+          tox-envs: 'lint,typing,docker,coverage-report'
           tox-plugins: "tox-docker"
 
   build:

--- a/src/spherexportal/domain.py
+++ b/src/spherexportal/domain.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field, validator
-from safir.pydantic import normalize_datetime
 
 approval_field = Field(
     None, description="Approval information for the document."
@@ -15,6 +14,14 @@ approval_field = Field(
 
 PROJECT_TIMEZONE = ZoneInfo("America/Los_Angeles")
 """Timezone to use for project times when displaying in the UI."""
+
+
+def _ensure_timezone(dt: datetime) -> datetime:
+    """Ensure that the datetime is timezone-aware in UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+
+    return dt
 
 
 class SpherexProject(BaseModel):
@@ -69,8 +76,8 @@ class GitHubRelease(BaseModel):
         )
 
     _normalize_datetime = validator(
-        "date_created", allow_reuse=True, pre=True
-    )(normalize_datetime)
+        "date_created", allow_reuse=True, pre=False
+    )(_ensure_timezone)
 
 
 class SpherexGitHubProject(SpherexProject):
@@ -122,8 +129,8 @@ class SpherexGitHubProject(SpherexProject):
         return "0"
 
     _normalize_datetime = validator(
-        "latest_commit_datetime", allow_reuse=True, pre=True
-    )(normalize_datetime)
+        "latest_commit_datetime", allow_reuse=True, pre=False
+    )(_ensure_timezone)
 
 
 class SpherexDocument(SpherexGitHubProject):

--- a/src/spherexportal/domain.py
+++ b/src/spherexportal/domain.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from typing import Optional
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
+from safir.pydantic import normalize_datetime
 
 approval_field = Field(
     None, description="Approval information for the document."
@@ -67,6 +68,10 @@ class GitHubRelease(BaseModel):
             "%Y-%m-%d"
         )
 
+    _normalize_datetime = validator(
+        "date_created", allow_reuse=True, pre=True
+    )(normalize_datetime)
+
 
 class SpherexGitHubProject(SpherexProject):
     """A GitHub-based SPHEREx documentation project."""
@@ -115,6 +120,10 @@ class SpherexGitHubProject(SpherexProject):
         if self.github_release is not None:
             return str(self.github_release.date_created.timestamp())
         return "0"
+
+    _normalize_datetime = validator(
+        "latest_commit_datetime", allow_reuse=True, pre=True
+    )(normalize_datetime)
 
 
 class SpherexDocument(SpherexGitHubProject):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py,coverage-report,typing,lint
+envlist = docker,coverage-report,typing,lint
 isolated_build = True
 
 [docker:redis]
@@ -15,17 +15,21 @@ healthcheck_start_period = 1
 
 [testenv]
 description = Run pytest against {envname}.
-docker =
-    redis
 deps =
     -r{toxinidir}/requirements/main.txt
     -r{toxinidir}/requirements/dev.txt
+
+[testenv:docker]
+description = Run pytest against {envname}.
+docker =
+    redis
 setenv =
     SAFIR_PROFILE=development
     SAFIR_LOG_LEVEL=DEBUG
     PORTAL_USE_MOCK_DATA=true
     PORTAL_DATASET_PATH={toxinidir}/tests/dataset.example.yaml
     PORTAL_ARQ_MODE = test
+    PORTAL_REDIS_URL = redis://localhost:6379/0
 commands =
     pytest --cov=spherexportal --cov-branch --cov-report= {posargs}
 
@@ -34,7 +38,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py
+    docker
 commands = coverage report
 
 [testenv:typing]


### PR DESCRIPTION
We observed an error where a timezone-naive datetime was being compared to a datetime with a timezone. By applying the `normalize_datetime` validator to the model we can ensure that the datetimes are also treated as UTC-aware.